### PR TITLE
Adds Podspec file

### DIFF
--- a/react-native-swipe-view.podspec
+++ b/react-native-swipe-view.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |spec|
+  spec.name         = "react-native-swipe-view"
+  spec.version      = "2.0.1"
+  spec.summary      = "Native container for a React Native view which supports swipe behavior (for swipe to delete and such)"
+  spec.homepage     = "https://github.com/wix/react-native-swipe-view"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author       = "Wix.com"
+  spec.platform     = :ios, "9.3"
+  spec.source       = { :git => "https://github.com/wix/react-native-swipe-view.git", :tag => "#{spec.version}" }
+  spec.source_files  = "ios/lib"
+  spec.dependency "React"
+end


### PR DESCRIPTION
This allows react-native-swipe-view to be used by React Native projects that use Cocoapods to manage dependencies.

Simply add `pod 'react-native-swipe-view', :path => '../node_modules/react-native-swipe-view'` to your `Podfile` and run `pod install`.